### PR TITLE
Add skip argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,16 @@ struct Examples {
     #[clap(short, long)]
     no_run: bool,
 
+    /// Skip <EXAMPLE> when running. (--skip=example1,example2)
+    #[clap(
+        short,
+        long,
+        value_parser,
+        use_value_delimiter = true,
+        value_name = "EXAMPLE"
+    )]
+    skip: Vec<OsString>,
+
     /// Pass these arguments along to cargo when running
     #[clap(raw = true)]
     cargo_args: Option<String>,
@@ -142,6 +152,11 @@ fn main() -> anyhow::Result<()> {
             if from == example.name().unwrap() {
                 run_examples = true;
             }
+        }
+
+        // skip any examples specified in the `skip` arg
+        if cli.skip.iter().any(|s| *s == example.name().unwrap()) {
+            continue;
         }
 
         if !run_examples {


### PR DESCRIPTION
Fixes #4

A couple points for discussion

- It wasn't completely obvious to me where to place the skip.

I placed it after after the check for `from` so that users could use both `skip` and `from` with the same example, which seems slightly silly but valid.

- With the current set of clap options, it's possible to use comma-separated example names **or** provide multiple `--skip` arguments.
 
I thought that clap at least might give some indication of the latter when building its help message, but that doesn't seem to be the case. I tossed in a parenthetical example of the comma separated scenario because that seems the most user-friendly to me.

Happy to revise, or close if this functionality isn't wanted.