### PR TITLE
Also read examples defined in the project's cargo manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,20 @@ name = "cargo-examples"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "cargo_toml",
  "clap",
  "tap",
  "xshell",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1204fe51a1e56042b8ec31d6407547ecd18f596b66f470dadb9abd9be9c843"
+dependencies = [
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -206,6 +217,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ anyhow = "1.0.65"
 clap = { version = "4.0", features = ["derive"] }
 tap = "1.0.1"
 xshell = "0.2.2"
+cargo_toml = "0.14.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
+use cargo_toml::Manifest;
 use clap::Parser;
 use tap::Tap;
 use xshell::{cmd, Shell};
@@ -50,6 +51,7 @@ enum Example {
     File(PathBuf),
     MultiFile(PathBuf),
     SubProject(PathBuf),
+    Named(OsString),
 }
 
 impl Example {
@@ -59,6 +61,7 @@ impl Example {
             Example::SubProject(path) | Example::MultiFile(path) => {
                 Some(path.parent()?.file_name()?)
             }
+            Example::Named(name) => Some(name.as_os_str()),
         }
     }
 }
@@ -94,7 +97,7 @@ fn main() -> anyhow::Result<()> {
     //     lot of projects use this for more involved examples
     //   - this can be ran as `cargo run --manifest-path examples/example_baz/Cargo.toml`
 
-    let examples: Vec<Example> = fs::read_dir(examples_dir)?
+    let mut examples: Vec<Example> = fs::read_dir(examples_dir)?
         .filter_map(|entry| entry.ok()) // ignore entries with errors
         .map(|entry| entry.path())
         .filter_map(|path| {
@@ -125,6 +128,15 @@ fn main() -> anyhow::Result<()> {
         .filter(|example| example.name().is_some())
         .collect::<Vec<_>>()
         .tap_mut(|examples| examples.sort_by(|a, b| a.name().unwrap().cmp(b.name().unwrap()))); // sort the files, so output and execution is deterministic when using `from`
+
+    let manifest = Manifest::from_path(manifest_path.clone())?;
+    for name in manifest
+        .example
+        .iter()
+        .filter_map(|product| product.name.clone())
+    {
+        examples.push(Example::Named(name.into()))
+    }
 
     if cli.list {
         // print all examples, unfiltered
@@ -159,7 +171,7 @@ fn main() -> anyhow::Result<()> {
         sh.change_dir(root_dir);
 
         let command = match example {
-            Example::File(_) => {
+            Example::File(_) | Example::Named(_) => {
                 let name = example.name().unwrap();
                 cmd!(
                     sh,


### PR DESCRIPTION
Fixes #6 

This might need some slight cleanup and definitely needs to be tested with more projects.

I think that there may be some overlap here with "subproject examples" described here: https://github.com/zxey/cargo-examples/issues/1#issuecomment-1312836189. So maybe examples should be deduplicated?

I'm also not sure if there might be other attributes in the `[[example]]` sections of a cargo manifest that need to be handled.

